### PR TITLE
Update Factorio version compatibility to 2.1 experimental

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,8 +1,8 @@
 {
 	"name": "Moon_Logic_2",
 	"version": "0.1.10",
-	"factorio_version": "2.0",
-	"dependencies": ["base >= 2.0", "? SchallCircuitGroup"],
+	"factorio_version": "2.1",
+	"dependencies": ["base >= 2.1", "? SchallCircuitGroup"],
 	"title": "Moon Logic 2",
 	"author": "OwnlyMe, IWTDU, mk-fg, smartguy1196, Chilla55",
 	"description": "Adds programmable Lua combinator. Based on Sandboxed LuaCombinator and LuaCombinator2 mods."


### PR DESCRIPTION
Updated factorio_version from 2.0 to 2.1 and dependencies from base >= 2.0 to base >= 2.1 to support Factorio 2.1 experimental patch.